### PR TITLE
fix multiprocess  create jobservice wrong

### DIFF
--- a/VirtualApp/lib/src/main/java/com/lody/virtual/client/VClient.java
+++ b/VirtualApp/lib/src/main/java/com/lody/virtual/client/VClient.java
@@ -264,7 +264,8 @@ public final class VClient extends IVClient.Stub {
     }
     public void initProcess(ClientConfig clientConfig) {
         if (this.clientConfig != null) {
-            throw new RuntimeException("reject init process: " + clientConfig.processName + ", this process is : " + this.clientConfig.processName);
+            //if prcesss have init kill all app rather than throw exception
+            VActivityManager.get().killAllApps();
         }
         this.clientConfig = clientConfig;
     }


### PR DESCRIPTION
修复偶发的多进程使用jobservice的时候vitrual无法将jobservice和进程正确关联导致jobservice一直无法被执行,最终消耗完100个jobservice问题从而无法启动vitrual的问,并限制同一应用最多同时申请30个